### PR TITLE
Fixed gifs for BSML 1.6.4

### DIFF
--- a/CustomBanners/Animations/AnimationUtilities.cs
+++ b/CustomBanners/Animations/AnimationUtilities.cs
@@ -29,13 +29,13 @@ namespace CustomBanners.Animations
                 FrameInfo currentFrameInfo = animationInfo.frames[i];
                 delays[i] = currentFrameInfo.delay;
 
-                Texture2D frameTexture = new Texture2D(currentFrameInfo.width, currentFrameInfo.height, TextureFormat.RGBA32, false);
+                Texture2D frameTexture = new Texture2D(currentFrameInfo.width, currentFrameInfo.height, TextureFormat.BGRA32, false);
                 try
                 {
                     frameTexture.name = name;
                     if (i != 0)
                         frameTexture.name += $" ({i})";
-                    frameTexture.SetPixels32(currentFrameInfo.colors);
+                    frameTexture.LoadRawTextureData(currentFrameInfo.colors);
                     frameTexture.Apply();
                 }
                 catch

--- a/CustomBanners/manifest.json
+++ b/CustomBanners/manifest.json
@@ -9,6 +9,6 @@
   "dependsOn": {
     "BSIPA": "^4.1.6",
     "SiraUtil": "^3.0.0",
-    "BeatSaberMarkupLanguage": "^1.5.3"
+    "BeatSaberMarkupLanguage": "^1.6.4"
   }
 }


### PR DESCRIPTION
In BSML 1.6.4 FrameInfo's colors field got changed from Color32 to byte, as a result this broke Custom Banner's gifs as AnimationUtilities treats FrameInfo as a Color32 type.